### PR TITLE
Fix - Under IE 11 selection date range isn't possible

### DIFF
--- a/src/client/components/DateInput/DateInput.less
+++ b/src/client/components/DateInput/DateInput.less
@@ -26,6 +26,7 @@
   left: 0;
   overflow: hidden;
   position: absolute;
+  display: block;
   top: 40px;
   z-index: 900;
 }

--- a/src/client/components/DateRangeInput/DateRangeInput.less
+++ b/src/client/components/DateRangeInput/DateRangeInput.less
@@ -7,7 +7,7 @@
 
 .opuscapita_date-range-input__picker-container {
   will-change: opacity, max-height;
-  display: inline-flex;
+  display: block;
   background: #fff;
   top: 40px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);

--- a/src/client/components/DayPicker/DayPicker.less
+++ b/src/client/components/DayPicker/DayPicker.less
@@ -15,15 +15,15 @@
   text-decoration: none;
 }
 
+.opuscapita_day-picker__picker .DayPicker {
+  padding-top: 0;
+}
+
 .opuscapita_day-picker,
 .opuscapita_day-picker__picker:focus,
 .opuscapita_day-picker__picker .DayPicker,
 .opuscapita_day-picker__picker .DayPicker-Day:focus {
   outline: none;
-}
-
-.opuscapita_day-picker__picker .DayPicker {
-  padding-bottom: 0.5rem;
 }
 
 .opuscapita_day-picker__picker .DayPicker-Day {
@@ -77,6 +77,9 @@
   border: none;
   position: relative;
   padding: 0 8px;
+  &::-ms-expand {
+    display: none;
+  }
 }
 
 .opuscapita_day-picker__caption-select:hover {


### PR DESCRIPTION
Fix for issue #8 
Additionally removed day *month* and *year* `<select />` arrows for IE